### PR TITLE
Fix MySQL schema and add missing product/store columns

### DIFF
--- a/mysql_migration.sql
+++ b/mysql_migration.sql
@@ -452,10 +452,9 @@ CREATE TABLE IF NOT EXISTS `transaction_audit_log` (
 
 -- Insert sample stores
 INSERT IGNORE INTO `stores` (`id`, `name`, `location`, `city`, `state`, `status`) VALUES
-('store_001', 'Downtown Store', '123 Main St', 'New York', 'NY', 'active'),
-('store_002', 'Mall Location', '456 Shopping Center', 'New York', 'NY', 'active'),
-('store_003', 'Uptown Branch', '789 North Ave', 'New York', 'NY', 'active'),
-('store_004', 'Westside Market', '321 West Blvd', 'New York', 'NY', 'active');
+('store_001', 'Downtown Fresh Market', '123 Main Street, Financial District', 'New York', 'NY', 'active'),
+('store_002', 'Manhattan Mall Supermarket', '456 Broadway, Herald Square', 'New York', 'NY', 'active'),
+('store_003', 'Brooklyn Heights Grocery', '789 Atlantic Avenue, Brooklyn Heights', 'Brooklyn', 'NY', 'active');
 
 -- Insert sample categories
 INSERT IGNORE INTO `categories` (`name`, `description`) VALUES
@@ -480,53 +479,82 @@ INSERT IGNORE INTO `suppliers` (`name`, `contact_email`, `contact_phone`, `addre
 
 -- Insert sample products
 INSERT IGNORE INTO `products` (`id`, `name`, `description`, `price`, `quantity`, `barcode`, `location_in_store`, `category`, `category_id`, `unit_price`, `current_stock`, `minimum_stock`, `maximum_stock`, `store_id`, `supplier_id`) VALUES
-('FV-BAN-001', 'Organic Bananas', 'Fresh organic bananas from local farms', 1.99, 100, '123456789012', 'Aisle 1-A', 'Fruits & Vegetables', 1, 1.99, 100, 20, 200, 'store_001', 1),
-('DA-MLK-003', 'Whole Milk', 'Fresh whole milk, 3.25% fat content', 3.79, 50, '123456789014', 'Aisle 3-B', 'Dairy', 2, 3.79, 50, 10, 100, 'store_001', 2),
-('MP-CHI-008', 'Chicken Breast', 'Fresh boneless chicken breast', 12.99, 25, '123456789019', 'Aisle 4-D', 'Meat & Poultry', 3, 12.99, 25, 5, 50, 'store_002', 5),
-('BV-ENE-015', 'Energy Drinks', 'High caffeine energy drinks', 2.99, 75, '123456789026', 'Aisle 5-E', 'Beverages', 4, 2.99, 75, 15, 150, 'store_004', 4),
-('SN-CHI-012', 'Potato Chips', 'Crispy potato chips, salt flavor', 3.99, 60, '123456789023', 'Aisle 6-G', 'Snacks', 5, 3.99, 60, 12, 120, 'store_003', NULL),
-('BV-COF-009', 'Ground Coffee', 'Premium ground coffee, medium roast', 8.99, 30, '123456789020', 'Aisle 5-E', 'Beverages', 4, 8.99, 30, 8, 60, 'store_002', 4),
-('DA-CHE-004', 'Cheddar Cheese', 'Aged cheddar cheese, sharp flavor', 5.99, 40, '123456789015', 'Aisle 3-B', 'Dairy', 2, 5.99, 40, 10, 80, 'store_002', 2),
-('SF-SAL-010', 'Fresh Salmon', 'Atlantic salmon, fresh caught', 18.99, 15, '123456789021', 'Aisle 4-F', 'Seafood', 6, 18.99, 15, 3, 30, 'store_003', 3),
-('BK-CRO-013', 'Croissants', 'Fresh French croissants', 1.99, 35, '123456789024', 'Aisle 2-C', 'Bakery', 7, 1.99, 35, 8, 70, 'store_003', NULL),
-('SN-NUT-017', 'Mixed Nuts', 'Deluxe mixed nuts, roasted', 7.99, 45, '123456789028', 'Aisle 6-G', 'Snacks', 5, 7.99, 45, 10, 90, 'store_004', NULL);
+-- Downtown Fresh Market Products
+('FV-BAN-001', 'Organic Bananas', 'Fresh organic bananas from Ecuador farms, pesticide-free and naturally ripened', 1.99, 120, '123456789012', 'Aisle 1-A', 'Fruits & Vegetables', 1, 1.99, 120, 20, 200, 'store_001', 1),
+('FV-APP-002', 'Red Delicious Apples', 'Crispy red apples from Washington state orchards, perfect for snacking or baking', 2.49, 85, '123456789013', 'Aisle 1-A', 'Fruits & Vegetables', 1, 2.49, 85, 15, 150, 'store_001', 1),
+('FV-CAR-003', 'Organic Carrots', 'Fresh bunched carrots grown organically, rich in beta-carotene and vitamins', 1.89, 65, '123456789017', 'Aisle 1-B', 'Fruits & Vegetables', 1, 1.89, 65, 20, 100, 'store_001', 1),
+('FV-TOM-004', 'Roma Tomatoes', 'Vine-ripened Roma tomatoes, ideal for sauces and cooking', 3.29, 40, '123456789030', 'Aisle 1-B', 'Fruits & Vegetables', 1, 3.29, 40, 10, 80, 'store_001', 1),
+('DA-MLK-005', 'Whole Milk', 'Fresh whole milk, 3.25% fat content, from local dairy farms', 3.79, 50, '123456789014', 'Aisle 3-A', 'Dairy', 2, 3.79, 50, 10, 100, 'store_001', 2),
+('DA-CHE-006', 'Sharp Cheddar Cheese', 'Aged sharp cheddar cheese, 8oz block, perfect for sandwiches and cooking', 5.99, 30, '123456789015', 'Aisle 3-A', 'Dairy', 2, 5.99, 30, 8, 60, 'store_001', 2),
+('DA-YOG-007', 'Greek Yogurt', 'Thick and creamy Greek-style yogurt, high protein, vanilla flavor', 4.99, 25, '123456789018', 'Aisle 3-B', 'Dairy', 2, 4.99, 25, 10, 50, 'store_001', 2),
+('BK-BRD-008', 'Artisan Sourdough Bread', 'Hand-crafted sourdough bread, slow-fermented for 24 hours', 4.49, 18, '123456789016', 'Bakery Counter', 'Bakery', 7, 4.49, 18, 5, 40, 'store_001', NULL),
+('BK-CRO-009', 'Butter Croissants', 'Fresh French butter croissants, flaky and buttery pastry', 1.99, 24, '123456789024', 'Bakery Counter', 'Bakery', 7, 1.99, 24, 8, 50, 'store_001', NULL),
+('BV-COF-010', 'Colombian Coffee Beans', 'Premium Colombian coffee beans, medium roast, single origin', 12.99, 22, '123456789020', 'Aisle 5-A', 'Beverages', 4, 12.99, 22, 8, 40, 'store_001', 4),
+
+-- Manhattan Mall Supermarket Products
+('MP-CHI-011', 'Chicken Breast', 'Fresh boneless, skinless chicken breast, antibiotic-free', 12.99, 35, '123456789019', 'Meat Counter', 'Meat & Poultry', 3, 12.99, 35, 10, 80, 'store_002', 5),
+('MP-GRB-012', 'Ground Beef 85/15', 'Fresh ground beef, 85% lean, perfect for burgers and meatballs', 8.99, 28, '123456789031', 'Meat Counter', 'Meat & Poultry', 3, 8.99, 28, 8, 50, 'store_002', 5),
+('MP-SAL-013', 'Atlantic Salmon Fillet', 'Fresh Atlantic salmon fillet, wild-caught, rich in omega-3', 18.99, 12, '123456789021', 'Seafood Counter', 'Seafood', 6, 18.99, 12, 3, 25, 'store_002', 3),
+('MP-SHR-014', 'Jumbo Shrimp', 'Fresh jumbo shrimp, peeled and deveined, ready to cook', 16.99, 20, '123456789032', 'Seafood Counter', 'Seafood', 6, 16.99, 20, 5, 40, 'store_002', 3),
+('BV-ENE-015', 'Energy Drinks', 'High caffeine energy drinks, assorted flavors, 16oz cans', 2.99, 75, '123456789026', 'Aisle 6-A', 'Beverages', 4, 2.99, 75, 20, 150, 'store_002', 4),
+('BV-SOD-016', 'Coca-Cola Classic', 'Classic Coca-Cola soda, 12-pack cans, refreshing cola taste', 5.99, 48, '123456789033', 'Aisle 6-B', 'Beverages', 4, 5.99, 48, 15, 100, 'store_002', 4),
+('BV-JUI-017', 'Fresh Orange Juice', 'Freshly squeezed orange juice, no pulp, vitamin C enriched', 4.49, 32, '123456789022', 'Aisle 6-A', 'Beverages', 4, 4.49, 32, 12, 60, 'store_002', 4),
+('SN-CHI-018', 'Kettle Cooked Chips', 'Artisan kettle cooked potato chips, sea salt flavor, thick cut', 3.99, 45, '123456789023', 'Aisle 7-A', 'Snacks', 5, 3.99, 45, 15, 90, 'store_002', NULL),
+('SN-NUT-019', 'Mixed Premium Nuts', 'Deluxe mixed nuts, roasted and salted, almonds, cashews, pecans', 7.99, 38, '123456789028', 'Aisle 7-B', 'Snacks', 5, 7.99, 38, 10, 80, 'store_002', NULL),
+('FZ-ICE-020', 'Vanilla Ice Cream', 'Premium vanilla ice cream, made with real vanilla beans, half gallon', 6.99, 15, '123456789027', 'Freezer A-1', 'Frozen Foods', 8, 6.99, 15, 5, 30, 'store_002', NULL),
+
+-- Brooklyn Heights Grocery Products
+('FV-LET-021', 'Romaine Lettuce', 'Fresh romaine lettuce heads, crisp leaves perfect for Caesar salads', 2.79, 42, '123456789034', 'Produce Section', 'Fruits & Vegetables', 1, 2.79, 42, 12, 80, 'store_003', 1),
+('FV-BRO-022', 'Fresh Broccoli', 'Fresh broccoli crowns, rich in vitamins and fiber, steam ready', 3.49, 35, '123456789035', 'Produce Section', 'Fruits & Vegetables', 1, 3.49, 35, 10, 60, 'store_003', 1),
+('FV-ONI-023', 'Yellow Onions', 'Fresh yellow onions, 3lb bag, essential cooking ingredient', 2.99, 28, '123456789036', 'Produce Section', 'Fruits & Vegetables', 1, 2.99, 28, 8, 50, 'store_003', 1),
+('FV-POT-024', 'Russet Potatoes', 'Idaho russet potatoes, 5lb bag, perfect for baking and frying', 4.99, 25, '123456789037', 'Produce Section', 'Fruits & Vegetables', 1, 4.99, 25, 6, 40, 'store_003', 1),
+('DA-BUT-025', 'Organic Butter', 'Organic unsalted butter, grass-fed cows, European style', 6.49, 20, '123456789038', 'Dairy Cooler', 'Dairy', 2, 6.49, 20, 5, 40, 'store_003', 2),
+('DA-EGG-026', 'Free Range Eggs', 'Free range chicken eggs, large size, dozen pack', 4.99, 30, '123456789039', 'Dairy Cooler', 'Dairy', 2, 4.99, 30, 8, 60, 'store_003', 2),
+('BK-BAG-027', 'Everything Bagels', 'Fresh everything bagels, 6-pack, topped with sesame, poppy seeds', 3.99, 16, '123456789040', 'Bakery Section', 'Bakery', 7, 3.99, 16, 4, 30, 'store_003', NULL),
+('BK-MUF-028', 'Blueberry Muffins', 'Fresh baked blueberry muffins, 4-pack, bursting with real blueberries', 5.99, 12, '123456789041', 'Bakery Section', 'Bakery', 7, 5.99, 12, 3, 25, 'store_003', NULL),
+('GR-RIC-029', 'Jasmine Rice', 'Premium jasmine rice, 5lb bag, aromatic long grain rice', 8.99, 18, '123456789042', 'Aisle 8-A', 'Grains', NULL, 8.99, 18, 4, 35, 'store_003', NULL),
+('GR-PAS-030', 'Italian Pasta', 'Authentic Italian durum wheat pasta, penne shape, 1lb box', 2.49, 40, '123456789029', 'Aisle 8-B', 'Grains', NULL, 2.49, 40, 12, 80, 'store_003', NULL),
+('HH-DET-031', 'Laundry Detergent', 'Concentrated laundry detergent, fresh scent, 64 loads', 12.99, 8, '123456789043', 'Aisle 9-A', 'Household Items', 9, 12.99, 8, 2, 20, 'store_003', NULL),
+('HH-SHP-032', 'Dish Soap', 'Ultra concentrated dish soap, grease cutting formula, 24oz bottle', 3.49, 15, '123456789044', 'Aisle 9-A', 'Household Items', 9, 3.49, 15, 4, 30, 'store_003', NULL);
 
 -- Insert sample inventory transactions
-INSERT IGNORE INTO `inventory_transactions` 
+INSERT IGNORE INTO `inventory_transactions`
 (`reference_number`, `transaction_type`, `product_id`, `product_name`, `category`, `quantity`, `unit_price`, `total_amount`, `store_id`, `store_name`, `transfer_to_store_id`, `transfer_to_store_name`, `user_id`, `user_name`, `notes`) VALUES
-('SALE-2024-001', 'Sale', 'FV-BAN-001', 'Organic Bananas', 'Fruits & Vegetables', 15, 1.99, 29.85, 'store_001', 'Downtown Store', NULL, NULL, 'emp_001', 'John Smith', 'Regular customer purchase'),
-('SALE-2024-002', 'Sale', 'DA-MLK-003', 'Whole Milk', 'Dairy', 4, 3.79, 15.16, 'store_001', 'Downtown Store', NULL, NULL, 'emp_001', 'John Smith', 'Family weekly shopping'),
-('SALE-2024-003', 'Sale', 'MP-CHI-008', 'Chicken Breast', 'Meat & Poultry', 2, 12.99, 25.98, 'store_002', 'Mall Location', NULL, NULL, 'emp_002', 'Sarah Johnson', 'Premium meat selection'),
-('RST-2024-006', 'Restock', 'FV-BAN-001', 'Organic Bananas', 'Fruits & Vegetables', 50, 1.20, 60.00, 'store_001', 'Downtown Store', NULL, NULL, 'mgr_001', 'Lisa Davis', 'Weekly delivery from Fresh Farm Co'),
-('TRF-2024-010', 'Transfer', 'DA-CHE-004', 'Cheddar Cheese', 'Dairy', 12, 5.99, 71.88, 'store_002', 'Mall Location', 'store_001', 'Downtown Store', 'mgr_002', 'Mike Wilson', 'Low stock transfer to high-demand location'),
-('ADJ-2024-012', 'Adjustment', 'SF-SAL-010', 'Fresh Salmon', 'Seafood', -3, 18.99, -56.97, 'store_003', 'Uptown Branch', NULL, NULL, 'mgr_003', 'Anna Garcia', 'Expired seafood disposal'),
-('SALE-2024-004', 'Sale', 'BV-ENE-015', 'Energy Drinks', 'Beverages', 8, 2.99, 23.92, 'store_004', 'Westside Market', NULL, NULL, 'emp_003', 'Tom Wilson', 'Bulk energy drink purchase'),
-('SALE-2024-005', 'Sale', 'SN-CHI-012', 'Potato Chips', 'Snacks', 6, 3.99, 23.94, 'store_003', 'Uptown Branch', NULL, NULL, 'emp_004', 'Emma Davis', 'Snack variety pack'),
-('RST-2024-007', 'Restock', 'BV-COF-009', 'Ground Coffee', 'Beverages', 25, 6.50, 162.50, 'store_002', 'Mall Location', NULL, NULL, 'mgr_002', 'Mike Wilson', 'Coffee supplier delivery'),
-('SALE-2024-008', 'Sale', 'BK-CRO-013', 'Croissants', 'Bakery', 10, 1.99, 19.90, 'store_003', 'Uptown Branch', NULL, NULL, 'emp_004', 'Emma Davis', 'Fresh bakery items');
+('SALE-2024-001', 'Sale', 'FV-BAN-001', 'Organic Bananas', 'Fruits & Vegetables', 15, 1.99, 29.85, 'store_001', 'Downtown Fresh Market', NULL, NULL, 'emp_001', 'John Smith', 'Regular customer purchase'),
+('SALE-2024-002', 'Sale', 'DA-MLK-005', 'Whole Milk', 'Dairy', 4, 3.79, 15.16, 'store_001', 'Downtown Fresh Market', NULL, NULL, 'emp_001', 'John Smith', 'Family weekly shopping'),
+('SALE-2024-003', 'Sale', 'MP-CHI-011', 'Chicken Breast', 'Meat & Poultry', 2, 12.99, 25.98, 'store_002', 'Manhattan Mall Supermarket', NULL, NULL, 'emp_002', 'Sarah Johnson', 'Premium meat selection'),
+('SALE-2024-004', 'Sale', 'BV-ENE-015', 'Energy Drinks', 'Beverages', 8, 2.99, 23.92, 'store_002', 'Manhattan Mall Supermarket', NULL, NULL, 'emp_002', 'Sarah Johnson', 'Bulk energy drink purchase'),
+('SALE-2024-005', 'Sale', 'SN-CHI-018', 'Kettle Cooked Chips', 'Snacks', 6, 3.99, 23.94, 'store_002', 'Manhattan Mall Supermarket', NULL, NULL, 'emp_002', 'Sarah Johnson', 'Snack variety pack'),
+('SALE-2024-006', 'Sale', 'BK-CRO-009', 'Butter Croissants', 'Bakery', 10, 1.99, 19.90, 'store_001', 'Downtown Fresh Market', NULL, NULL, 'emp_001', 'John Smith', 'Fresh bakery items'),
+('SALE-2024-007', 'Sale', 'FV-LET-021', 'Romaine Lettuce', 'Fruits & Vegetables', 5, 2.79, 13.95, 'store_003', 'Brooklyn Heights Grocery', NULL, NULL, 'emp_003', 'Emma Davis', 'Salad ingredients'),
+('SALE-2024-008', 'Sale', 'DA-EGG-026', 'Free Range Eggs', 'Dairy', 3, 4.99, 14.97, 'store_003', 'Brooklyn Heights Grocery', NULL, NULL, 'emp_003', 'Emma Davis', 'Breakfast essentials'),
+('RST-2024-009', 'Restock', 'FV-BAN-001', 'Organic Bananas', 'Fruits & Vegetables', 50, 1.20, 60.00, 'store_001', 'Downtown Fresh Market', NULL, NULL, 'mgr_001', 'Lisa Davis', 'Weekly delivery from Fresh Farm Co'),
+('RST-2024-010', 'Restock', 'MP-CHI-011', 'Chicken Breast', 'Meat & Poultry', 25, 8.50, 212.50, 'store_002', 'Manhattan Mall Supermarket', NULL, NULL, 'mgr_002', 'Mike Wilson', 'Fresh meat delivery'),
+('RST-2024-011', 'Restock', 'BV-COF-010', 'Colombian Coffee Beans', 'Beverages', 15, 9.50, 142.50, 'store_001', 'Downtown Fresh Market', NULL, NULL, 'mgr_001', 'Lisa Davis', 'Premium coffee restock'),
+('TRF-2024-012', 'Transfer', 'DA-CHE-006', 'Sharp Cheddar Cheese', 'Dairy', 8, 5.99, 47.92, 'store_001', 'Downtown Fresh Market', 'store_003', 'Brooklyn Heights Grocery', 'mgr_001', 'Lisa Davis', 'Stock redistribution'),
+('ADJ-2024-013', 'Adjustment', 'MP-SAL-013', 'Atlantic Salmon Fillet', 'Seafood', -2, 18.99, -37.98, 'store_002', 'Manhattan Mall Supermarket', NULL, NULL, 'mgr_002', 'Mike Wilson', 'Expired seafood disposal'),
+('SALE-2024-014', 'Sale', 'BK-MUF-028', 'Blueberry Muffins', 'Bakery', 4, 5.99, 23.96, 'store_003', 'Brooklyn Heights Grocery', NULL, NULL, 'emp_003', 'Emma Davis', 'Fresh baked goods'),
+('SALE-2024-015', 'Sale', 'GR-PAS-030', 'Italian Pasta', 'Grains', 12, 2.49, 29.88, 'store_003', 'Brooklyn Heights Grocery', NULL, NULL, 'emp_003', 'Emma Davis', 'Bulk pasta purchase');
 
 -- Insert sample user store access
 INSERT IGNORE INTO `user_store_access` (`user_id`, `store_id`, `access_level`) VALUES
 ('emp_001', 'store_001', 'write'),
 ('emp_002', 'store_002', 'write'),
-('emp_003', 'store_004', 'write'),
-('emp_004', 'store_003', 'write'),
+('emp_003', 'store_003', 'write'),
 ('mgr_001', 'store_001', 'admin'),
 ('mgr_002', 'store_002', 'admin'),
 ('mgr_003', 'store_003', 'admin'),
-('mgr_004', 'store_004', 'admin'),
 ('admin_001', 'store_001', 'admin'),
 ('admin_001', 'store_002', 'admin'),
-('admin_001', 'store_003', 'admin'),
-('admin_001', 'store_004', 'admin');
+('admin_001', 'store_003', 'admin');
 
 -- Insert sample demand forecasting models
 INSERT IGNORE INTO `demand_forecasting_models` (`model_name`, `model_type`, `model_accuracy`, `training_status`, `store_id`, `category_id`) VALUES
 ('Linear Regression Model v1', 'linear_regression', 78.50, 'completed', 'store_001', 1),
 ('ARIMA Model v1', 'arima', 82.30, 'completed', 'store_001', 2),
 ('LSTM Deep Learning Model', 'lstm', 85.70, 'completed', 'store_002', 3),
-('Prophet Seasonal Model', 'prophet', 79.20, 'completed', 'store_003', 4),
-('Ensemble Model v1', 'ensemble', 87.10, 'completed', 'store_004', 5);
+('Prophet Seasonal Model', 'prophet', 79.20, 'completed', 'store_002', 4),
+('Ensemble Model v1', 'ensemble', 87.10, 'completed', 'store_003', 5);
 
 -- ============================================================================
 -- PERFORMANCE INDEXES


### PR DESCRIPTION
## Purpose
Fix the MySQL migration script by adding missing columns to the products and stores tables as identified by users. The script was missing essential product fields (price, description, quantity, barcode, location_in_store) and store fields (city, state, status). Additionally, streamline the sample data to focus on three stores with more comprehensive product descriptions.

## Code changes
- **Products table**: Added `description`, `price`, `quantity`, `barcode`, and `location_in_store` columns with appropriate data types and constraints
- **Stores table**: Added `city`, `state`, and `status` columns with ENUM for status field
- **Sample data**: Reduced from 4 stores to 3 stores (Downtown Fresh Market, Manhattan Mall Supermarket, Brooklyn Heights Grocery)
- **Product catalog**: Expanded from 10 to 32 products with detailed descriptions, proper categorization, and complete field data
- **Database indexes**: Added barcode index for products table to improve query performance
- **Data consistency**: Updated all related sample data (inventory transactions, user access) to reference the new 3-store structure

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/0713abf77fe845ac81102fae16cbf756/zen-forge)

👀 [Preview Link](https://0713abf77fe845ac81102fae16cbf756-zen-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0713abf77fe845ac81102fae16cbf756</projectId>-->
<!--<branchName>zen-forge</branchName>-->